### PR TITLE
Fix Client to be insise YCP::Clients module and have Client suffix

### DIFF
--- a/spec/y2r/ast_spec.rb
+++ b/spec/y2r/ast_spec.rb
@@ -599,10 +599,12 @@ module Y2R::AST
         )
 
         node.to_ruby.should == [
-          "class YCP::Clients::C",
+          "module YCP::Clients",
+          "  class CClient",
+          "  end",
           "end",
           "",
-          "YCP::Clients::C.new.main"
+          "YCP::Clients::CClient.new.main"
         ].join("\n")
       end
 
@@ -627,15 +629,17 @@ module Y2R::AST
         )
 
         node.to_ruby.should == [
-          "class YCP::Clients::C",
-          "  def main",
-          "    @i = 42",
-          "    @j = 43",
-          "    @k = 44",
+          "module YCP::Clients",
+          "  class CClient",
+          "    def main",
+          "      @i = 42",
+          "      @j = 43",
+          "      @k = 44",
+          "    end",
           "  end",
           "end",
           "",
-          "YCP::Clients::C.new.main"
+          "YCP::Clients::CClient.new.main"
         ].join("\n")
       end
 
@@ -651,19 +655,21 @@ module Y2R::AST
         )
 
         node.to_ruby.should == [
-          "class YCP::Clients::C",
-          "  include I18n",
-          "  textdomain \"d\"",
+          "module YCP::Clients",
+          "  class CClient",
+          "    include I18n",
+          "    textdomain \"d\"",
           "",
-          "  include I18n",
-          "  textdomain \"e\"",
+          "    include I18n",
+          "    textdomain \"e\"",
           "",
-          "  include I18n",
-          "  textdomain \"f\"",
+          "    include I18n",
+          "    textdomain \"f\"",
           "",
+          "  end",
           "end",
           "",
-          "YCP::Clients::C.new.main"
+          "YCP::Clients::CClient.new.main"
         ].join("\n")
       end
 
@@ -706,29 +712,31 @@ module Y2R::AST
         )
 
         node.to_ruby.should == [
-          "class YCP::Clients::C",
+          "module YCP::Clients",
+          "  class CClient",
           "",
-          "  def f",
-          "    return 42",
+          "    def f",
+          "      return 42",
           "",
-          "    nil",
+          "      nil",
+          "    end",
+          "",
+          "    def g",
+          "      return 43",
+          "",
+          "      nil",
+          "    end",
+          "",
+          "    def h",
+          "      return 44",
+          "",
+          "      nil",
+          "    end",
+          "",
           "  end",
-          "",
-          "  def g",
-          "    return 43",
-          "",
-          "    nil",
-          "  end",
-          "",
-          "  def h",
-          "    return 44",
-          "",
-          "    nil",
-          "  end",
-          "",
           "end",
           "",
-          "YCP::Clients::C.new.main"
+          "YCP::Clients::CClient.new.main"
         ].join("\n")
       end
     end

--- a/spec/y2r_spec.md
+++ b/spec/y2r_spec.md
@@ -29,13 +29,15 @@ Y2R translates YCP `nil` as Ruby `nil`.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    @v = nil
+module YCP::Clients
+  class DefaultClient
+    def main
+      @v = nil
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### Booleans
@@ -54,14 +56,16 @@ Y2R translates YCP booleans as Ruby booelans.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    @t = true
-    @f = false
+module YCP::Clients
+  class DefaultClient
+    def main
+      @t = true
+      @f = false
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### Integers
@@ -80,13 +84,15 @@ integers can overflow while `Fixnum`s are just converted into `Bignum`s).
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    @i = 42
+module YCP::Clients
+  class DefaultClient
+    def main
+      @i = 42
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### Floats
@@ -106,14 +112,16 @@ level so the conversion is lossless.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    @f1 = 42.0
-    @f2 = 42.1
+module YCP::Clients
+  class DefaultClient
+    def main
+      @f1 = 42.0
+      @f2 = 42.1
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### Symbols
@@ -133,13 +141,15 @@ will always have US-ASCII encoding.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    @s = :abcd
+module YCP::Clients
+  class DefaultClient
+    def main
+      @s = :abcd
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### Strings
@@ -159,13 +169,15 @@ explain a bit more.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    @s = "abcd"
+module YCP::Clients
+  class DefaultClient
+    def main
+      @s = "abcd"
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### Paths
@@ -184,13 +196,15 @@ encoding?
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    @p = Path.new(".abcd")
+module YCP::Clients
+  class DefaultClient
+    def main
+      @p = Path.new(".abcd")
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### Lists
@@ -209,14 +223,16 @@ Y2R translates YCP lists as Ruby arrays.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    @l1 = []
-    @l2 = [42, 43, 44]
+module YCP::Clients
+  class DefaultClient
+    def main
+      @l1 = []
+      @l2 = [42, 43, 44]
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### Maps
@@ -235,14 +251,16 @@ Y2R translates YCP maps as Ruby hashes.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    @m1 = {}
-    @m2 = { :a => 42, :b => 43, :c => 44 }
+module YCP::Clients
+  class DefaultClient
+    def main
+      @m1 = {}
+      @m2 = { :a => 42, :b => 43, :c => 44 }
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### Terms
@@ -261,14 +279,16 @@ Y2R translates YCP terms as instances of the `YCP::Term` class
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    @t1 = Term.new(:a)
-    @t2 = Term.new(:a, 42, 43, 44)
+module YCP::Clients
+  class DefaultClient
+    def main
+      @t1 = Term.new(:a)
+      @t2 = Term.new(:a, 42, 43, 44)
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### Blocks
@@ -286,15 +306,17 @@ Y2R translates YCP blocks as Ruby lambdas.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    @b = lambda {
-      Builtins.y2milestone("M1")
-    }
+module YCP::Clients
+  class DefaultClient
+    def main
+      @b = lambda {
+        Builtins.y2milestone("M1")
+      }
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 Expressions
@@ -320,18 +342,20 @@ Y2R translates YCP local variables as Ruby local variables.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
+module YCP::Clients
+  class DefaultClient
 
-  def f
-    i = 42
-    j = i
+    def f
+      i = 42
+      j = i
 
-    nil
+      nil
+    end
+
   end
-
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 Y2R translates YCP variables at client toplevel as Ruby instance variables.
@@ -348,14 +372,16 @@ Y2R translates YCP variables at client toplevel as Ruby instance variables.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    @i = 42
-    @j = @i
+module YCP::Clients
+  class DefaultClient
+    def main
+      @i = 42
+      @j = @i
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 Y2R translates YCP variables at module toplevel as Ruby instance variables.
@@ -454,13 +480,15 @@ method.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    @f = Convert.convert(42, :from => "integer", :to => "float")
+module YCP::Clients
+  class DefaultClient
+    def main
+      @f = Convert.convert(42, :from => "integer", :to => "float")
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### Builtin Calls
@@ -487,20 +515,22 @@ builtins in Ruby.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
+module YCP::Clients
+  class DefaultClient
+    def main
 
 
-    Builtins.time
-    Builtins.random(100)
-    SCR.Dir(Path.new(".syseditor.section"))
-    WFM.Args
-    @f = Builtins::Float.abs(-42.0)
-    @l = Builtins::List.reverse([42, 43, 44])
+      Builtins.time
+      Builtins.random(100)
+      SCR.Dir(Path.new(".syseditor.section"))
+      WFM.Args
+      @f = Builtins::Float.abs(-42.0)
+      @l = Builtins::List.reverse([42, 43, 44])
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 Y2R handles YCP builtin calls with a block as the last argument specially. It
@@ -517,15 +547,17 @@ converts the block into a Ruby block.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    Builtins.foreach([42, 43, 44]) { |i|
-      Builtins.y2milestone("M1")
-    }
+module YCP::Clients
+  class DefaultClient
+    def main
+      Builtins.foreach([42, 43, 44]) { |i|
+        Builtins.y2milestone("M1")
+      }
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 Y2R handles YCP builtin calls with a double quote expression as the last
@@ -542,13 +574,15 @@ argument specially. It converts the expression into a Ruby block.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    Builtins.maplist([42, 43, 44]) { |i| Ops.multiply(i, i) }
+module YCP::Clients
+  class DefaultClient
+    def main
+      Builtins.maplist([42, 43, 44]) { |i| Ops.multiply(i, i) }
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### `_` Calls
@@ -568,16 +602,18 @@ Y2R translates YCP `_` calls as calls of the `_` method.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  include I18n
-  textdomain "helloworld"
+module YCP::Clients
+  class DefaultClient
+    include I18n
+    textdomain "helloworld"
 
-  def main
-    @s = _("Hello, world!")
+    def main
+      @s = _("Hello, world!")
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### Function Calls
@@ -612,40 +648,42 @@ Y2R translates YCP function calls as Ruby method calls.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    f1
-    @a = "a"
-    @b = "b"
-    @c = "c"
-    f2(@a, @b, @c)
-    f3(@a, @b, @c)
+module YCP::Clients
+  class DefaultClient
+    def main
+      f1
+      @a = "a"
+      @b = "b"
+      @c = "c"
+      f2(@a, @b, @c)
+      f3(@a, @b, @c)
+    end
+
+    def f1
+      return 42
+
+      nil
+    end
+
+    def f2(a, b, c)
+      a = YCP.copy(a)
+      b = YCP.copy(b)
+      c = YCP.copy(c)
+      return 42
+
+      nil
+    end
+
+    def f3(a, b, c)
+      return 42
+
+      nil
+    end
+
   end
-
-  def f1
-    return 42
-
-    nil
-  end
-
-  def f2(a, b, c)
-    a = YCP.copy(a)
-    b = YCP.copy(b)
-    c = YCP.copy(c)
-    return 42
-
-    nil
-  end
-
-  def f3(a, b, c)
-    return 42
-
-    nil
-  end
-
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### Comparison Operators
@@ -670,18 +708,20 @@ because their behavior differs from the behavior of YCP operators in some cases.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    @b1 = Ops.equal(42, 43)
-    @b2 = Ops.not_equal(42, 43)
-    @b3 = Ops.less_than(42, 43)
-    @b4 = Ops.greater_than(42, 43)
-    @b5 = Ops.less_or_equal(42, 43)
-    @b6 = Ops.greater_or_equal(42, 43)
+module YCP::Clients
+  class DefaultClient
+    def main
+      @b1 = Ops.equal(42, 43)
+      @b2 = Ops.not_equal(42, 43)
+      @b3 = Ops.less_than(42, 43)
+      @b4 = Ops.greater_than(42, 43)
+      @b5 = Ops.less_or_equal(42, 43)
+      @b6 = Ops.greater_or_equal(42, 43)
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### Arithmetic Operators
@@ -709,19 +749,21 @@ because their behavior differs from the behavior of YCP operators in some cases.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    @i = 42
-    @i1 = Ops.unary_minus(@i)
-    @i2 = Ops.add(42, 43)
-    @i3 = Ops.subtract(42, 43)
-    @i4 = Ops.multiply(42, 43)
-    @i5 = Ops.divide(42, 43)
-    @i6 = Ops.modulo(42, 43)
+module YCP::Clients
+  class DefaultClient
+    def main
+      @i = 42
+      @i1 = Ops.unary_minus(@i)
+      @i2 = Ops.add(42, 43)
+      @i3 = Ops.subtract(42, 43)
+      @i4 = Ops.multiply(42, 43)
+      @i5 = Ops.divide(42, 43)
+      @i6 = Ops.modulo(42, 43)
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### Bitwise Operators
@@ -746,18 +788,20 @@ because their behavior differs from the behavior of YCP operators in some cases.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    @i1 = Ops.bitwise_not(42)
-    @i2 = Ops.bitwise_and(42, 43)
-    @i3 = Ops.bitwise_or(42, 43)
-    @i4 = Ops.bitwise_xor(42, 43)
-    @i5 = Ops.shift_left(42, 43)
-    @i6 = Ops.shift_right(42, 43)
+module YCP::Clients
+  class DefaultClient
+    def main
+      @i1 = Ops.bitwise_not(42)
+      @i2 = Ops.bitwise_and(42, 43)
+      @i3 = Ops.bitwise_or(42, 43)
+      @i4 = Ops.bitwise_xor(42, 43)
+      @i5 = Ops.shift_left(42, 43)
+      @i6 = Ops.shift_right(42, 43)
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### Logical Operators
@@ -782,16 +826,18 @@ because their behavior differs from the behavior of YCP operators in some cases.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    @b = true
-    @b1 = Ops.logical_not(@b)
-    @b2 = Ops.logical_and(true, false)
-    @b3 = Ops.logical_or(true, false)
+module YCP::Clients
+  class DefaultClient
+    def main
+      @b = true
+      @b1 = Ops.logical_not(@b)
+      @b2 = Ops.logical_and(true, false)
+      @b3 = Ops.logical_or(true, false)
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### Ternary Operator
@@ -811,14 +857,16 @@ Y2R translates YCP ternary operator as Ruby ternary operator.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    @b = true
-    @i = @b ? 42 : 43
+module YCP::Clients
+  class DefaultClient
+    def main
+      @b = true
+      @i = @b ? 42 : 43
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### Index Operator
@@ -837,13 +885,15 @@ that implements its behavior. There is no equivalent operator in Ruby.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    @i = Ops.index([42, 43, 44], [1], 0)
+module YCP::Clients
+  class DefaultClient
+    def main
+      @i = Ops.index([42, 43, 44], [1], 0)
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### Double Quote Operator
@@ -861,13 +911,15 @@ Y2R translates YCP double quote operator as a Ruby lambda.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    @b = lambda { 42 }
+module YCP::Clients
+  class DefaultClient
+    def main
+      @b = lambda { 42 }
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 Statements
@@ -890,14 +942,16 @@ Y2R translates YCP `import` statement as a `YCP.import` call.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    YCP.import("String")
+module YCP::Clients
+  class DefaultClient
+    def main
+      YCP.import("String")
 
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### `textdomain` Statement
@@ -916,13 +970,15 @@ call to set the text domain.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  include I18n
-  textdomain "users"
+module YCP::Clients
+  class DefaultClient
+    include I18n
+    textdomain "users"
 
+  end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### Assignments
@@ -942,14 +998,16 @@ Y2R translates simple YCP assignments as Ruby assignments.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    @i = 42
-    @i = 43
+module YCP::Clients
+  class DefaultClient
+    def main
+      @i = 42
+      @i = 43
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 Y2R translates YCP assignments with brackets as a call of a method in the
@@ -969,14 +1027,16 @@ in Ruby.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    @l = [42, 43, 44]
-    Ops.assign(@l, [0], 45)
+module YCP::Clients
+  class DefaultClient
+    def main
+      @l = [42, 43, 44]
+      Ops.assign(@l, [0], 45)
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### `return` Statement
@@ -999,23 +1059,25 @@ statement.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
+module YCP::Clients
+  class DefaultClient
 
-  def f1
-    return
+    def f1
+      return
 
-    nil
+      nil
+    end
+
+    def f2
+      return 42
+
+      nil
+    end
+
   end
-
-  def f2
-    return 42
-
-    nil
-  end
-
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 Y2R translates YCP `return` statement inside block as Ruby `next` statement.
@@ -1031,20 +1093,22 @@ Y2R translates YCP `return` statement inside block as Ruby `next` statement.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    Builtins.maplist([42, 43, 44]) { |i|
-      j = 42
-      next j
-    }
-    Builtins.foreach([42, 43, 44]) { |i|
-      j = 42
-      next
-    }
+module YCP::Clients
+  class DefaultClient
+    def main
+      Builtins.maplist([42, 43, 44]) { |i|
+        j = 42
+        next j
+      }
+      Builtins.foreach([42, 43, 44]) { |i|
+        j = 42
+        next
+      }
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### `break` Statement
@@ -1063,15 +1127,17 @@ statement.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    while true
-      break
+module YCP::Clients
+  class DefaultClient
+    def main
+      while true
+        break
+      end
     end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 Y2R translates YCP `break` statement inside a repeat statement as Ruby `next`
@@ -1088,15 +1154,17 @@ statement.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    begin
-      break
-    end until true
+module YCP::Clients
+  class DefaultClient
+    def main
+      begin
+        break
+      end until true
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 Y2R translates YCP `break` statement inside block as Ruby `raise` statement that
@@ -1111,15 +1179,17 @@ raises `YCP::Break`.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    Builtins.foreach([42, 43, 44]) { |i|
-      raise Break
-    }
+module YCP::Clients
+  class DefaultClient
+    def main
+      Builtins.foreach([42, 43, 44]) { |i|
+        raise Break
+      }
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### `continue` Statement
@@ -1137,15 +1207,17 @@ Y2R translates YCP `continue` statement inside loops as Ruby `next` statement.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    while true
-      next
+module YCP::Clients
+  class DefaultClient
+    def main
+      while true
+        next
+      end
     end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 Y2R translates YCP `continue` statement inside block as Ruby `next` statement.
@@ -1159,15 +1231,17 @@ Y2R translates YCP `continue` statement inside block as Ruby `next` statement.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    Builtins.foreach([42, 43, 44]) { |i|
-      next
-    }
+module YCP::Clients
+  class DefaultClient
+    def main
+      Builtins.foreach([42, 43, 44]) { |i|
+        next
+      }
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### Function Definitions
@@ -1209,50 +1283,52 @@ pass-by-value semantics for all types except `boolean`, `integer` and `symbol`,
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
+module YCP::Clients
+  class DefaultClient
 
-  def f1
-    return 42
+    def f1
+      return 42
 
-    nil
+      nil
+    end
+
+    def f2(a, b, c)
+      return 42
+
+      nil
+    end
+
+    def f3(a, b, c)
+      return 42
+
+      nil
+    end
+
+    def f4(a, b, c)
+      return 42
+
+      nil
+    end
+
+    def f5(a, b, c)
+      return 42
+
+      nil
+    end
+
+    def f6(a, b, c)
+      a = YCP.copy(a)
+      b = YCP.copy(b)
+      c = YCP.copy(c)
+      return 42
+
+      nil
+    end
+
   end
-
-  def f2(a, b, c)
-    return 42
-
-    nil
-  end
-
-  def f3(a, b, c)
-    return 42
-
-    nil
-  end
-
-  def f4(a, b, c)
-    return 42
-
-    nil
-  end
-
-  def f5(a, b, c)
-    return 42
-
-    nil
-  end
-
-  def f6(a, b, c)
-    a = YCP.copy(a)
-    b = YCP.copy(b)
-    c = YCP.copy(c)
-    return 42
-
-    nil
-  end
-
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 Y2R does not support nested functions. This is mostly because Ruby doesn't have
@@ -1298,15 +1374,17 @@ Y2R translates YCP statement blocks as Ruby statements.
 #### Error Message
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    Builtins.y2milestone("M1")
-    Builtins.y2milestone("M2")
-    Builtins.y2milestone("M3")
+module YCP::Clients
+  class DefaultClient
+    def main
+      Builtins.y2milestone("M1")
+      Builtins.y2milestone("M2")
+      Builtins.y2milestone("M3")
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### `if` Statement
@@ -1330,20 +1408,22 @@ Y2R translates YCP `if` statement as Ruby `if` statement.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    if true
-      Builtins.y2milestone("M1")
-    end
-    if true
-      Builtins.y2milestone("M2")
-    else
-      Builtins.y2milestone("M3")
+module YCP::Clients
+  class DefaultClient
+    def main
+      if true
+        Builtins.y2milestone("M1")
+      end
+      if true
+        Builtins.y2milestone("M2")
+      else
+        Builtins.y2milestone("M3")
+      end
     end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### `while` Statement
@@ -1362,15 +1442,17 @@ Y2R translates YCP `while` statement as Ruby `while` statement.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    while true
-      Builtins.y2milestone("M1")
+module YCP::Clients
+  class DefaultClient
+    def main
+      while true
+        Builtins.y2milestone("M1")
+      end
     end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### `repeat` Statement
@@ -1390,15 +1472,17 @@ Y2R translates YCP `repeat` statement as Ruby `until` statement.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    begin
-      Builtins.y2milestone("M1")
-    end until true
+module YCP::Clients
+  class DefaultClient
+    def main
+      begin
+        Builtins.y2milestone("M1")
+      end until true
+    end
   end
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### Clients
@@ -1427,29 +1511,31 @@ Y2R translates YCP clients as Ruby classes that are instantiated.
 #### Ruby Code
 
 ```ruby
-class YCP::Clients::Default
-  def main
-    YCP.import("String")
+module YCP::Clients
+  class DefaultClient
+    def main
+      YCP.import("String")
 
-    @i = 42
-    @j = 43
+      @i = 42
+      @j = 43
+    end
+
+    def f
+      return 42
+
+      nil
+    end
+
+    def g
+      return 43
+
+      nil
+    end
+
   end
-
-  def f
-    return 42
-
-    nil
-  end
-
-  def g
-    return 43
-
-    nil
-  end
-
 end
 
-YCP::Clients::Default.new.main
+YCP::Clients::DefaultClient.new.main
 ```
 
 ### Modules


### PR DESCRIPTION
Reason for YCP::Clients module is that this namespace does not exist,
so ruby raise unknown constant.
Client suffix is needed because in ycp is often client which have same name as
module like sysconfig.ycp and Sysconfig.ycp with module and when Sysconfig
module is called, then wrong class is used.
Reason why commit is not split into two is that tests have so much repetition
of client code, that change it even once was quite lot of work.
