### PR TITLE
Use ruby equivalent for Ops.equal and non_equal.

### DIFF
--- a/lib/y2r/ast/ycp.rb
+++ b/lib/y2r/ast/ycp.rb
@@ -470,9 +470,12 @@ module Y2R
       end
 
       class Compare < Node
+        OPS_TO_OPS = {
+          "==" => "==",
+          "!=" => "!="
+        }
+
         OPS_TO_METHODS = {
-          "==" => "equal",
-          "!=" => "not_equal",
           "<"  => "less_than",
           ">"  => "greater_than",
           "<=" => "less_or_equal",
@@ -480,13 +483,23 @@ module Y2R
         }
 
         def compile(context)
-          Ruby::MethodCall.new(
-            :receiver => Ruby::Variable.new(:name => "Ops"),
-            :name     => OPS_TO_METHODS[op],
-            :args     => [lhs.compile(context), rhs.compile(context)],
-            :block    => nil,
-            :parens   => true
-          )
+          if OPS_TO_OPS[op]
+            Ruby::BinaryOperator.new(
+              :op       => OPS_TO_OPS[op],
+              :lhs      => lhs.compile(context),
+              :rhs      => rhs.compile(context)
+            )
+          elsif OPS_TO_METHODS[op]
+            Ruby::MethodCall.new(
+              :receiver => Ruby::Variable.new(:name => "Ops"),
+              :name     => OPS_TO_METHODS[op],
+              :args     => [lhs.compile(context), rhs.compile(context)],
+              :block    => nil,
+              :parens   => true
+            )
+          else
+            raise "Unknown compare operator #{op}."
+          end
         end
       end
 

--- a/spec/y2r/ast/ycp_spec.rb
+++ b/spec/y2r/ast/ycp_spec.rb
@@ -1526,6 +1526,14 @@ module Y2R::AST
         )
       end
 
+      def ruby_operator(name)
+        Ruby::BinaryOperator.new(
+          :op  => name,
+          :lhs => @ruby_literal_42,
+          :rhs => @ruby_literal_43
+        )
+      end
+
       it "returns correct AST node" do
         ycp_node_equal            = ycp_compare("==")
         ycp_node_not_equal        = ycp_compare("!=")
@@ -1534,8 +1542,8 @@ module Y2R::AST
         ycp_node_less_or_equal    = ycp_compare("<=")
         ycp_node_greater_or_equal = ycp_compare(">=")
 
-        ruby_node_equal            = ruby_ops_call("equal")
-        ruby_node_not_equal        = ruby_ops_call("not_equal")
+        ruby_node_equal            = ruby_operator("==")
+        ruby_node_not_equal        = ruby_operator("!=")
         ruby_node_less_than        = ruby_ops_call("less_than")
         ruby_node_greater_than     = ruby_ops_call("greater_than")
         ruby_node_less_or_equal    = ruby_ops_call("less_or_equal")

--- a/spec/y2r_spec.md
+++ b/spec/y2r_spec.md
@@ -821,8 +821,8 @@ Yast::DefaultClient.new.main
 ### Comparison Operators
 
 Y2R translates YCP comparison operators as calls of methods in the `Yast::Ops`
-module that implement their behavior. Equivalent Ruby operators can't be used
-because their behavior differs from the behavior of YCP operators in some cases.
+module that implement their behavior or ruby equivalent if behavior is same in
+all cases.
 
 #### YCP (fragment)
 
@@ -838,8 +838,8 @@ boolean b6 = 42 >= 43;
 #### Ruby (fragment)
 
 ```ruby
-b1 = Ops.equal(42, 43)
-b2 = Ops.not_equal(42, 43)
+b1 = 42 == 43
+b2 = 42 != 43
 b3 = Ops.less_than(42, 43)
 b4 = Ops.greater_than(42, 43)
 b5 = Ops.less_or_equal(42, 43)


### PR DESCRIPTION
It works same, so it just makes code more beatiful.
